### PR TITLE
Support for Version and Help Arguments

### DIFF
--- a/cmd/protoc-gen-elm/main.go
+++ b/cmd/protoc-gen-elm/main.go
@@ -21,6 +21,9 @@ import (
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
+const version = "0.0.2"
+const docUrl = "https://github.com/jalandis/elm-protobuf"
+
 //go:embed Protobuf.elm
 var pbLibrary string
 
@@ -30,6 +33,7 @@ var excludedFiles = map[string]bool{
 }
 
 type parameters struct {
+	Version          bool
 	Debug            bool
 	RemoveDeprecated bool
 }
@@ -57,6 +61,15 @@ func parseParameters(input *string) (parameters, error) {
 }
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "--version" {
+		fmt.Fprintf(os.Stdout, "%v %v\n", filepath.Base(os.Args[0]), version)
+		os.Exit(0)
+	}
+	if len(os.Args) == 2 && os.Args[1] == "--help" {
+		fmt.Fprintf(os.Stdout, "See "+docUrl+" for usage information.\n")
+		os.Exit(0)
+	}
+
 	data, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatalf("Could not read request from STDIN: %v", err)

--- a/scripts/release
+++ b/scripts/release
@@ -83,4 +83,4 @@ build windows 386
 build windows amd64
 build windows arm
 
-find ./bin -maxdepth 1 -mindepth 1 ! -name '*.tar.gz' -exec tar -zcvf {}.tar.gz {}  \;
+find "${ROOT}/protoc-gen-elm//bin" -maxdepth 1 -mindepth 1 ! -name '*.tar.gz' -exec tar -zcvf {}.tar.gz {}  \;

--- a/scripts/release
+++ b/scripts/release
@@ -3,29 +3,39 @@
 set -euo pipefail
 set -x
 
-readonly CMD_DIR=./cmd/protoc-gen-elm
+readonly ROOT="$(git rev-parse --show-toplevel)"
+readonly CMD_DIR="${ROOT}/cmd/protoc-gen-elm"
 
 # Make sure the current commit is tagged, using the following command:
 # git tag -a v0.0.2 -m 'release'
 
 # Remove the leading "v" from the tag, if necessary.
-readonly VERSION=$(git tag --contains | tr -d v)
+readonly NEW_VERSION=$(git tag --contains | tr -d v)
 
 # Exit if a tag does not exist for the current commit.
-[[ -z $VERSION ]] && exit
+if [[ -z $NEW_VERSION ]]; then
+  echo "Missing required version tag."
+  exit 1
+fi
+
+"${ROOT}/scripts/compile_test_plugin"
+
+readonly FOUND_VERSION="$("${ROOT}/elm-test-project/elm-protobuf-test" --version | cut -d' ' -f2)"
+if [[ "${FOUND_VERSION}" != "${NEW_VERSION}" ]]; then
+  echo "Versions do not match.  Be sure to update the version defined in main.go"
+  exit 1
+fi
 
 function build() {
     OS="${1}"
     ARCH="${2}"
-    OUT="elm-protobuf-${VERSION}-${OS}-${ARCH}"
+    OUT="elm-protobuf-${NEW_VERSION}-${OS}-${ARCH}"
 
-    GOOS="${OS}" GOARCH="${ARCH}" GO111MODULE=on go build -o "./bin/${OUT}" "${CMD_DIR}"
+    GOOS="${OS}" GOARCH="${ARCH}" GO111MODULE=on go build -o "${ROOT}/protoc-gen-elm/bin/${OUT}" "${CMD_DIR}"
 }
 
 # Disable cgo in order to ensure static binaries.
 export CGO_ENABLED=0
-
-pushd protoc-gen-elm
 
 # List of all supported GO platforms from `go tool dist list`
 build aix ppc64

--- a/scripts/run_elm_tests
+++ b/scripts/run_elm_tests
@@ -18,5 +18,4 @@ protoc \
     "${ROOT}"/elm-test-project/tests/proto/*.proto
 
 cd "${ROOT}/elm-test-project"
-pwd
 elm-test


### PR DESCRIPTION
This mirrors the arguments for the GO code generation executable and will allow a simple check for the version of the installed executable.